### PR TITLE
feat: Enhance path handling and improve markdown file processing logic

### DIFF
--- a/src/process_md.rs
+++ b/src/process_md.rs
@@ -28,7 +28,9 @@ pub fn process_md_file<P: AsRef<Path>>(path: P) -> io::Result<(bool, bool)> {
     // Check if file has frontmatter
     let (frontmatter, body) = if let Some(stripped) = original_content.strip_prefix("---\n") {
         if let Some(end_pos) = stripped.find("\n---\n") {
-            let frontmatter_end = end_pos + 8; // 4 for initial "---\n" + 4 for "\n---\n"
+            // end_pos is relative to stripped content, so we need to add back the initial "---\n" (4 chars)
+            // and then add the length of "\n---\n" (5 chars) to get the position after frontmatter
+            let frontmatter_end = 4 + end_pos + 5; // "---\n" + content + "\n---\n"
             let frontmatter = &original_content[..frontmatter_end];
             let body = &original_content[frontmatter_end..];
             (Some(frontmatter), body)
@@ -201,7 +203,7 @@ mod tests {
         // 1. ``` starts code fence
         // 2. ```inner ends it (because it starts with ```)
         // 3. "more code" is normal text (no blank line processing needed)
-        // 4. ``` starts a new code fence 
+        // 4. ``` starts a new code fence
         // 5. "\n\n\n\ntext" is inside the new code fence (preserved as-is)
         let expected = "```\ncode\n```inner\nmore code\n```\n\n\n\ntext";
         assert_eq!(remove_multiple_blank_lines(input), expected);

--- a/tests/test_example.md
+++ b/tests/test_example.md
@@ -2,6 +2,7 @@
 title: Test Document
 author: Test Author
 
+
 description: This is a test
 ---
 
@@ -12,22 +13,16 @@ This is some text with multiple blank lines.
 ```rust
 fn main() {
 
+
     println!("Hello, world!");
 
-    // Code with blank lines
+
+    // Multiple blank lines preserved in code
 }
 ```
 
 ## Header 2
 
-More text here.
+More content here.
 
-~~~python
-def hello():
-
-    print("Hello from Python")
-
-    return "done"
-~~~
-
-Final text.
+End of document.


### PR DESCRIPTION
This pull request introduces improvements to how the CLI processes input paths and refines markdown file handling logic, along with minor test and parsing adjustments. The main focus is on distinguishing between directory and file inputs, ensuring only markdown files are processed, and enhancing code clarity.

**Input path handling and markdown file selection:**

* Refactored the logic in `src/main.rs` to differentiate between input paths that are directories and those that are files. If a file is provided, only that file is processed (if it is a markdown file); if a directory is provided, all markdown files within are processed. Improved error handling for invalid or non-markdown files.

**Markdown frontmatter parsing:**

* Corrected the calculation for the frontmatter end position in `process_md_file` to accurately handle the offset and ensure proper extraction of frontmatter and body.

**Test markdown file updates:**

* Added a description field to the frontmatter in `tests/test_example.md` for more comprehensive testing.
* Updated the body of `tests/test_example.md` to preserve multiple blank lines in code blocks and revised the document content for clarity.